### PR TITLE
Fix NRE in BaseControllerPointer when locomotion system is not available

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Runtime/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Runtime/Features/UX/Scripts/Pointers/BaseControllerPointer.cs
@@ -186,7 +186,7 @@ namespace XRTK.SDK.UX.Pointers
                 if (this == null) { return; }
 
                 lateRegisterTeleport = false;
-                LocomotionSystem.Register(gameObject);
+                LocomotionSystem?.Register(gameObject);
                 SetCursor();
             }
             else


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

The `BaseControllerPointer` had a hard dependency on the Locomotion System left. I noticed in a project where I removed the system completely from the XRTK root profile because I don't need it, that a NRE is fired because the system is not available.

This PR addresses that.