### PR TITLE
Fix destroyOnSourceLost not exposed in controller visualizer inspector

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Editor/Input/Handlers/ControllerPoseSynchronizerInspector.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Editor/Input/Handlers/ControllerPoseSynchronizerInspector.cs
@@ -18,6 +18,7 @@ namespace XRTK.SDK.Editor.Input.Handlers
         private SerializedProperty useSourcePoseData;
         private SerializedProperty poseAction;
         private SerializedProperty handedness;
+        private SerializedProperty destroyOnSourceLost;
 
         protected bool DrawHandednessProperty = true;
 
@@ -26,6 +27,7 @@ namespace XRTK.SDK.Editor.Input.Handlers
             useSourcePoseData = serializedObject.FindProperty(nameof(useSourcePoseData));
             poseAction = serializedObject.FindProperty(nameof(poseAction));
             handedness = serializedObject.FindProperty(nameof(handedness));
+            destroyOnSourceLost = serializedObject.FindProperty(nameof(destroyOnSourceLost));
         }
 
         public override void OnInspectorGUI()
@@ -58,6 +60,8 @@ namespace XRTK.SDK.Editor.Input.Handlers
                         handedness.enumValueIndex = (int)currentHandedness;
                     }
                 }
+
+                EditorGUILayout.PropertyField(destroyOnSourceLost);
 
                 EditorGUI.indentLevel--;
             }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

The serialized `destroyOnSourceLost` field was not exposed in the inspector for `ControllerPoseSynchronizer` / Controller Visualizer and there was no way of changing it in a prefab.